### PR TITLE
Fix fill indexes undefined error

### DIFF
--- a/fill_indexes.js
+++ b/fill_indexes.js
@@ -22,11 +22,11 @@ var indexes = require("./lib/indexes.js"),
     request = require("request"),
     utils = require("./lib/utils");
 
-var createUrl = function createUrl(api, extra) {
+function createUrl(api, extra) {
     return utils.getAPIProtocol(api) + "://" + utils.getAPIHost(api) + ":" + utils.getAPIPort(api) + extra;
-};
+}
 
-var genericRequest = function genericRequest(options, extra) {
+function genericRequest(options, extra) {
     return new Promise((resolve, reject) => {
       request(options, function (err, response, body) {
           if (err) {
@@ -50,14 +50,14 @@ var genericRequest = function genericRequest(options, extra) {
           }
       });
     });
-};
+}
 
-var getProducts = function getProducts() {
+function getProducts() {
     var url = createUrl("DSProductCatalog", "/DSProductCatalog/api/catalogManagement/v2/productSpecification");
     return genericRequest(url);
-};
+}
 
-var getOfferings = function getOfferings(catalog, qstring) {
+function getOfferings(catalog, qstring) {
      // For every catalog!
     var url;
     if (catalog) {
@@ -74,34 +74,34 @@ var getOfferings = function getOfferings(catalog, qstring) {
         field: "catalog",
         value: catalog
     });
-};
+}
 
-var getCatalogs = function getCatalogs() {
+function getCatalogs() {
     var url = createUrl("DSProductCatalog", "/DSProductCatalog/api/catalogManagement/v2/catalog");
     return genericRequest(url);
-};
+}
 
-var getInventory = function getInventory() {
+function getInventory() {
     var url = createUrl("DSProductInventory", "/DSProductInventory/api/productInventory/v2/product");
     return genericRequest(url);
-};
+}
 
-var getOrders = function getOrders() {
+function getOrders() {
     var url = createUrl("DSProductOrdering", "/DSProductOrdering/api/productOrdering/v2/productOrder");
     return genericRequest(url);
-};
+}
 
-var downloadProducts = function downloadProducts() {
+function downloadProducts() {
     return getProducts()
         .then(indexes.saveIndexProduct);
-};
+}
 
-var downloadOfferings = function downloadOfferings(catalog, qstring) {
+function downloadOfferings(catalog, qstring) {
     return getOfferings(catalog, qstring)
         .then(indexes.saveIndexOffering);
-};
+}
 
-var downloadCatalogOfferings = function downloadCatalogOfferings(catalogs) {
+function downloadCatalogOfferings(catalogs) {
     var promise = Promise.resolve();
     if (catalogs.length) {
         catalogs.forEach(function (catalog) {
@@ -124,22 +124,22 @@ var downloadCatalogOfferings = function downloadCatalogOfferings(catalogs) {
         return indexes.saveIndexCatalog(catalogs)
     });
     return promise;
-};
+}
 
-var downloadCatalogs = function downloadCatalogs() {
+function downloadCatalogs() {
     return getCatalogs()
         .then(downloadCatalogOfferings);
-};
+}
 
-var downloadInventory = function downloadInventory() {
+function downloadInventory() {
     return getInventory()
         .then(indexes.saveIndexInventory);
-};
+}
 
-var downloadOrdering = function downloadOrdering() {
+function downloadOrdering() {
     return getOrders()
         .then(indexes.saveIndexOrder);
-};
+}
 
 indexes.init()
     .then(downloadProducts)
@@ -148,4 +148,4 @@ indexes.init()
     .then(downloadOrdering)
     .then(indexes.close)
     .then(() => console.log("All saved!"))
-    .catch(e => console.log("Error: ", e.stack));
+    .catch(e => console.error("Error: ", e, e.message));

--- a/fill_indexes.js
+++ b/fill_indexes.js
@@ -30,7 +30,7 @@ function genericRequest(options, extra) {
     return new Promise((resolve, reject) => {
       request(options, function (err, response, body) {
           if (err) {
-              console.log(err);
+              console.error(err);
               reject(err);
               return;
           }
@@ -45,7 +45,7 @@ function genericRequest(options, extra) {
               }
               resolve(parsedBody);
           } else {
-              reject("Unexpected HTTP error code: " + response.statusCode);
+              reject(new Error("Unexpected HTTP error code: " + response.statusCode));
               return;
           }
       });
@@ -92,16 +92,19 @@ function getOrders() {
 }
 
 function downloadProducts() {
+    console.log('Download products...')
     return getProducts()
         .then(indexes.saveIndexProduct);
 }
 
 function downloadOfferings(catalog, qstring) {
+    console.log('Download offerings...')
     return getOfferings(catalog, qstring)
         .then(indexes.saveIndexOffering);
 }
 
 function downloadCatalogOfferings(catalogs) {
+    console.log('Download catalog offerings...')
     var promise = Promise.resolve();
     if (catalogs.length) {
         catalogs.forEach(function (catalog) {
@@ -127,16 +130,19 @@ function downloadCatalogOfferings(catalogs) {
 }
 
 function downloadCatalogs() {
+    console.log('Download catalogs...')
     return getCatalogs()
         .then(downloadCatalogOfferings);
 }
 
 function downloadInventory() {
+    console.log('Download inventory...')
     return getInventory()
         .then(indexes.saveIndexInventory);
 }
 
 function downloadOrdering() {
+    console.log('Download ordering...')
     return getOrders()
         .then(indexes.saveIndexOrder);
 }


### PR DESCRIPTION
- Reject an error rather than plain text.
- Add more logging (so that we know at which step it breaks):
```
proxy_1  | Creating indexes...
proxy_1  | Download products...
proxy_1  | Download catalogs...
proxy_1  | Download catalog offerings...
proxy_1  | Download offerings...
proxy_1  | Download inventory...
proxy_1  | Download ordering...
proxy_1  | All saved!
```