### PR TITLE
Build docker image within CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,18 @@ jobs:
       - run:
           name: Build the docker image
           command: |
-            docker build -t digicatsynch/logicproxy7:$CIRCLE_SHA1 .
+            docker build -t logicproxy7 .
+
+      - run:
+          name: Tag the docker image
+          command: |
+            docker tag logicproxy7 digicatsynch/logicproxy7:$CIRCLE_SHA1
+            docker tag logicproxy7 digicatsynch/logicproxy7:ci-$CIRCLE_BUILD_NUM
 
       - run:
           name: Push the docker image
           command: |
+            docker push digicatsynch/logicproxy7:$CIRCLE_SHA1
             docker push digicatsynch/logicproxy7:ci-$CIRCLE_BUILD_NUM
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,8 @@
 version: 2
 jobs:
-  build:
+  test:
     docker:
       - image: circleci/node:6.17.0
-
     steps:
       - checkout
 
@@ -35,3 +34,30 @@ jobs:
           key: v1-node-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - node_modules
+
+  docker-build:
+    docker:
+      - image: docker:18.01.0-ce-git
+    steps:
+      - checkout
+
+      - setup_remote_docker
+
+      - run:
+          name: Build the docker image
+          command: |
+            docker build -t digicatsynch/logicproxy7:$CIRCLE_SHA1 .
+
+      - run:
+          name: Push the docker image
+          command: |
+            docker push digicatsynch/logicproxy7:$CIRCLE_SHA1
+
+workflows:
+  version: 2
+  logic-proxy:
+    jobs:
+      - test
+      - docker-build:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,11 @@ jobs:
       - setup_remote_docker
 
       - run:
+          name: Login to docker
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+      - run:
           name: Build the docker image
           command: |
             docker build -t digicatsynch/logicproxy7:$CIRCLE_SHA1 .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           paths:
             - node_modules
 
-  docker-build:
+  docker-ci-build:
     docker:
       - image: docker:18.01.0-ce-git
     steps:
@@ -56,13 +56,13 @@ jobs:
       - run:
           name: Push the docker image
           command: |
-            docker push digicatsynch/logicproxy7:$CIRCLE_SHA1
+            docker push digicatsynch/logicproxy7:ci-$CIRCLE_BUILD_NUM
 
 workflows:
   version: 2
   logic-proxy:
     jobs:
       - test
-      - docker-build:
+      - docker-ci-build:
           requires:
             - test


### PR DESCRIPTION
Build & push the docker image in CircleCI when the tests are successful.
The image is tagged in the following ways:
- `digicatsynch/logicproxy7:$CIRCLE_SHA1` (ex: `digicatsynch/logicproxy7:b1a644a41c532399f5e1412fef95a1aa3c0cd69577`)
- `digicatsynch/logicproxy7:ci-$CIRCLE_BUILD_NUM` (ex: `digicatsynch/logicproxy7:ci-42`)

Feature branches & version tags will be implemented in a forthcoming PR.