### PR TITLE
Monitor backend errors with Sentry

### DIFF
--- a/etc/config.js
+++ b/etc/config.js
@@ -16,6 +16,7 @@ const env = cleanEnv(process.env, {
   EXPRESS_SESSION_SECRET: str({ default: "keyboard cat" }),
   EXPRESS_THEME: str({ default: "" }),
   // Version
+  SENTRY_DSN: url({ default: undefined }),
   VERSION: str({ default: "6.4.0" }),
   RELEASE_DATE: str({ default: "" }),
   GIT_HASH: str({ default: "" }),
@@ -145,6 +146,9 @@ const config = {
   logOutPath: env.EXPRESS_LOGOUT_PATH,
   sessionSecret: env.EXPRESS_SESSION_SECRET,
   theme: env.EXPRESS_THEME,
+  sentry: {
+    dsn: env.SENTRY_DSN
+  },
   version: env.VERSION,
   releaseDate: env.RELEASE_DATE,
   gitHash: env.GIT_HASH,

--- a/etc/config.js
+++ b/etc/config.js
@@ -17,6 +17,7 @@ const env = cleanEnv(process.env, {
   EXPRESS_THEME: str({ default: "" }),
   // Version
   SENTRY_DSN: url({ default: undefined }),
+  SENTRY_ENVIRONMENT: str({ devDefault: "devel" }),
   VERSION: str({ default: "6.4.0" }),
   RELEASE_DATE: str({ default: "" }),
   GIT_HASH: str({ default: "" }),
@@ -147,7 +148,8 @@ const config = {
   sessionSecret: env.EXPRESS_SESSION_SECRET,
   theme: env.EXPRESS_THEME,
   sentry: {
-    dsn: env.SENTRY_DSN
+    dsn: env.SENTRY_DSN,
+    environment: env.SENTRY_ENVIRONMENT
   },
   version: env.VERSION,
   releaseDate: env.RELEASE_DATE,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "UPM",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@sentry/node": "^5.0.5",
+    "@sentry/node": "^4.0.0",
     "async": "^1.5.0",
     "async-lock": "^0.3.8",
     "base64url": "1.0.x",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "UPM",
   "license": "AGPL-3.0",
   "dependencies": {
+    "@sentry/node": "^5.0.5",
     "async": "^1.5.0",
     "async-lock": "^0.3.8",
     "base64url": "1.0.x",


### PR DESCRIPTION
To be enabled, the service must have those env setup:
```sh
SENTRY_DSN=https:/xxx@sentry.io/yyy
SENTRY_ENVIRONMENT=staging
```