### PR TITLE
Minify build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,17 +19,20 @@ VOLUME /business-ecosystem-logic-proxy/lib
 COPY ./package.json .
 RUN npm install --production --no-optional
 
+# Minify frontend
+COPY ./default_locales default_locales
+COPY ./public public
+COPY ./views views
+COPY ./collect_static.js .
+RUN node collect_static.js
+
 # Project sources
 COPY ./controllers controllers
 COPY ./db db
-COPY ./default_locales default_locales
 COPY ./etc etc
 COPY ./lib lib
 COPY ./locales locales
-COPY ./public public
-COPY ./views views
 COPY ./config.js .
-COPY ./collect_static.js .
 COPY ./fill_indexes.js .
 COPY ./log_config.json .
 COPY ./server.js .

--- a/collect_static.js
+++ b/collect_static.js
@@ -17,15 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint no-console: 0 */
-const config = require('./config');
 const compressor = require('node-minify');
 const fs = require('fs');
 const mergedirs = require('merge-dirs');
 const path = require('path');
 
 const staticPath = './static';
-
-const debug = !(process.env.NODE_ENV == 'production');
 
 const deleteContents = function (path) {
     fs.readdirSync(path).forEach((file) => {
@@ -42,21 +39,6 @@ const deleteContents = function (path) {
 const deleteDir = function (path) {
     deleteContents(path);
     fs.rmdirSync(path);
-};
-
-const loadTheme = function () {
-    // Check if the provided theme exists
-    if (!fs.existsSync('./themes/' + config.theme)) {
-        console.log('The configured theme ' + config.theme + ' has not been provided');
-        process.exit(1);
-    }
-
-    console.log('Loading Theme ' + config.theme);
-
-    // Merge default files with theme ones
-    mergedirs.default('./themes/' + config.theme, './static', 'overwrite');
-
-    console.log('Theme loaded');
 };
 
 const minimizejs = function () {
@@ -92,7 +74,7 @@ const minimizejs = function () {
 
 const mergeLocales = function() {
     // Check if the plugin includes locales
-    let localesDir = './themes/' + config.theme + '/locales'
+    let localesDir = './themes/locales'
     if (fs.existsSync(localesDir) && fs.statSync(localesDir).isDirectory()) {
         // Parse and merge files
         fs.readdirSync(localesDir).map(f => {
@@ -120,12 +102,6 @@ const mergeLocales = function() {
     }
 }
 
-// Check if a theme has been provided or the system is in production
-if (!config.theme && debug) {
-    console.log('The default theme is configured and debug mode is active, nothing to do');
-    process.exit(1);
-}
-
 // Delete prev static files
 if(fs.existsSync(staticPath)) {
     deleteContents(staticPath);
@@ -137,14 +113,7 @@ if(fs.existsSync(staticPath)) {
 mergedirs.default('./views', './static/views', 'overwrite');
 mergedirs.default('./public', './static/public', 'overwrite');
 
-if (config.theme) {
-    // If a theme has been provided merge it with default files
-    loadTheme();
-    mergeLocales();
-}
 
-if (!debug) {
-    // If the system is in production compile jades and minimize js files
-    minimizejs();
-    console.log('JavaScript files minimized');
-}
+// If the system is in production compile jades and minimize js files
+minimizejs();
+console.log('JavaScript files minimized');

--- a/collect_static.js
+++ b/collect_static.js
@@ -17,103 +17,77 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint no-console: 0 */
-const compressor = require('node-minify');
-const fs = require('fs');
-const mergedirs = require('merge-dirs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
+const compressor = require("node-minify");
+const mergedirs = require("merge-dirs");
 
-const staticPath = './static';
+const staticPath = "./static";
 
-const deleteContents = function (path) {
-    fs.readdirSync(path).forEach((file) => {
-        let curPath = path + "/" + file;
+function deleteContents(path) {
+  fs.readdirSync(path).forEach(file => {
+    let curPath = path + "/" + file;
 
-        if (fs.lstatSync(curPath).isDirectory()) { // recurse
-            deleteDir(curPath);
-        } else { // delete file
-            fs.unlinkSync(curPath);
-        }
-    });
-};
-
-const deleteDir = function (path) {
-    deleteContents(path);
-    fs.rmdirSync(path);
-};
-
-const minimizejs = function () {
-    let files = [];
-    let output = staticPath + '/public/resources/core/js/bae.min.js';
-
-    let compileJs = (jsFile) => {
-        if (jsFile.indexOf('.js') != -1) {
-            files.push(jsFile);
-            console.log('Including ' + jsFile);
-        }
-    };
-
-    let compileFiles = (d) => fs.statSync(d).isDirectory() ? fs.readdirSync(d).map(f => compileFiles(path.join(d, f))) : compileJs(d);
-    compileFiles(staticPath + '/public/resources/core/js');
-
-    console.log('Generating ' + output);
-    compressor.minify({
-        compressor: 'gcc',
-        input: files,
-        output: output,
-        callback: function () {
-            files.forEach((f) => {
-                fs.unlinkSync(f);
-            });
-            fs.rmdirSync(staticPath + '/public/resources/core/js/controllers');
-            fs.rmdirSync(staticPath + '/public/resources/core/js/directives');
-            fs.rmdirSync(staticPath + '/public/resources/core/js/services');
-            fs.rmdirSync(staticPath + '/public/resources/core/js/routes');
-        }
-    });
-};
-
-const mergeLocales = function() {
-    // Check if the plugin includes locales
-    let localesDir = './themes/locales'
-    if (fs.existsSync(localesDir) && fs.statSync(localesDir).isDirectory()) {
-        // Parse and merge files
-        fs.readdirSync(localesDir).map(f => {
-            let locale = path.join('./default_locales', f);
-            let destLocale = path.join('./locales', f).replace('json', 'js');
-            let localeJson;
-
-            if (fs.existsSync(locale)) {
-                // There is an existing locale, merge with the theme
-                let themeLocaleJson = require('./' + path.join(localesDir, f));
-                localeJson = require('./' + locale);
-
-                Object.assign(localeJson, themeLocaleJson);
-
-            } else {
-                // There is not a locale, save it
-                localeJson = require('./' + path.join(localesDir, f));
-            }
-            // Write new locale
-            fs.open(destLocale, 'w', (err, fd) => {
-                fs.writeSync(fd, JSON.stringify(localeJson));
-                console.log('Locale ' + f + ' updated');
-            });
-        });
+    if (fs.lstatSync(curPath).isDirectory()) {
+      // recurse
+      deleteDir(curPath);
+    } else {
+      // delete file
+      fs.unlinkSync(curPath);
     }
+  });
+}
+
+function deleteDir(path) {
+  deleteContents(path);
+  fs.rmdirSync(path);
+}
+
+function minimizejs() {
+  let files = [];
+  let output = staticPath + "/public/resources/core/js/bae.min.js";
+
+  let compileJs = jsFile => {
+    if (jsFile.indexOf(".js") != -1) {
+      files.push(jsFile);
+      console.log("Including " + jsFile);
+    }
+  };
+
+  let compileFiles = d =>
+    fs.statSync(d).isDirectory()
+      ? fs.readdirSync(d).map(f => compileFiles(path.join(d, f)))
+      : compileJs(d);
+  compileFiles(staticPath + "/public/resources/core/js");
+
+  console.log("Generating " + output);
+  compressor.minify({
+    compressor: "gcc",
+    input: files,
+    output: output,
+    callback: function() {
+      files.forEach(f => {
+        fs.unlinkSync(f);
+      });
+      fs.rmdirSync(staticPath + "/public/resources/core/js/controllers");
+      fs.rmdirSync(staticPath + "/public/resources/core/js/directives");
+      fs.rmdirSync(staticPath + "/public/resources/core/js/services");
+      fs.rmdirSync(staticPath + "/public/resources/core/js/routes");
+    }
+  });
 }
 
 // Delete prev static files
-if(fs.existsSync(staticPath)) {
-    deleteContents(staticPath);
+if (fs.existsSync(staticPath)) {
+  deleteContents(staticPath);
 } else {
-    fs.mkdirSync(staticPath);
+  fs.mkdirSync(staticPath);
 }
 
 // Copy default theme files
-mergedirs.default('./views', './static/views', 'overwrite');
-mergedirs.default('./public', './static/public', 'overwrite');
-
+mergedirs.default("./views", "./static/views", "overwrite");
+mergedirs.default("./public", "./static/public", "overwrite");
 
 // If the system is in production compile jades and minimize js files
 minimizejs();
-console.log('JavaScript files minimized');
+console.log("JavaScript files minimized");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./etc:/business-ecosystem-logic-proxy/etc
       - ./lib:/business-ecosystem-logic-proxy/lib
       - ./views:/business-ecosystem-logic-proxy/views
+      - ./public:/business-ecosystem-logic-proxy/public
     environment:
       - NODE_ENV=development
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -67,9 +67,6 @@ done
 echo "Creating indexes..."
 node fill_indexes.js
 
-echo "Generate the frontend..."
-node collect_static.js
-
 if [ "$NODE_ENV" == "development" ]; then
   echo "Starting server in development mode..."
   nodemon --verbose --ignore 'locales/*.js' server.js

--- a/server.js
+++ b/server.js
@@ -321,6 +321,10 @@ app.use(config.portalPrefix + '/', express.static(__dirname + staticPath + '/pub
 app.set('views', __dirname + staticPath + '/views');
 app.set('view engine', 'jade');
 
+if (debug) {
+  app.disable('view cache');
+}
+
 app.locals.taxRate = config.taxRate || 20;
 
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Minify the frontend during the docker build, rather than in the entrypoint script (deployment).
Also enable hot reloading for frontend changes:
- It is now possible to change make change on the frontend (`public/` & `views/` folders) and these changes will appear automatically after a refresh, without need to rebuild nor redeploy the server.