### PR TITLE
Sidebar changes

### DIFF
--- a/views/partials/inventory/sidebar.jade
+++ b/views/partials/inventory/sidebar.jade
@@ -4,7 +4,7 @@
       a(ui-sref="inventory.product", ui-sref-opts="{ reload: true, inherit: false }")
         span.item-icon.fa.fa-file
         span.item-text #{ __("Acquired data offerings") }
-    li(ui-sref-active="active")
-      a(ui-sref="inventory.productOrder", ui-sref-opts="{ reload: true, inherit: false }")
-        span.item-icon.fa.fa-shopping-bag
-        span.item-text #{ __("Data orders") }
+    //- li(ui-sref-active="active")
+    //-   a(ui-sref="inventory.productOrder", ui-sref-opts="{ reload: true, inherit: false }")
+    //-     span.item-icon.fa.fa-shopping-bag
+    //-     span.item-text #{ __("Data orders") }

--- a/views/partials/inventory/sidebar.jade
+++ b/views/partials/inventory/sidebar.jade
@@ -3,7 +3,7 @@
     li(ui-sref-active="active")
       a(ui-sref="inventory.product", ui-sref-opts="{ reload: true, inherit: false }")
         span.item-icon.fa.fa-file
-        span.item-text #{ __("Products") }
+        span.item-text #{ __("Acquired data offerings") }
     li(ui-sref-active="active")
       a(ui-sref="inventory.productOrder", ui-sref-opts="{ reload: true, inherit: false }")
         span.item-icon.fa.fa-shopping-bag


### PR DESCRIPTION
- Change the label inventory->products into inventory->acquired data offerings

- Hide inventory->data orders. Some information in that tab is useless and misleading and we don't need it now. Comment out the related code for now as we might need it in the future.