### PR TITLE
Disable minification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY ./default_locales default_locales
 COPY ./public public
 COPY ./views views
 COPY ./collect_static.js .
-RUN node collect_static.js
+#RUN node collect_static.js
 
 # Project sources
 COPY ./controllers controllers


### PR DESCRIPTION
Fix the hot-reloading for the javascript sources by disabling the minification of js files.

The minification isn't super effective anyway and is done through a custom script instead of using a generic bundler like webpack. I would recommend to stick without it until we start to develop the new frontend.