### PR TITLE
Fix bug file exists

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -51,14 +51,14 @@ GLASSFISH_SCH=$(get_protocol "$ENDPOINT_INVENTORY_APP_SSL")
 GLASSFISH_PATH=${ENDPOINT_INVENTORY_PATH}
 
 echo "Testing Glasfish APIs deployed"
-wget ${GLASSFISH_SCH}://${GLASSFISH_HOST}:${GLASSFISH_PORT}/${GLASSFISH_PATH}
+wget -qO- ${GLASSFISH_SCH}://${GLASSFISH_HOST}:${GLASSFISH_PORT}/${GLASSFISH_PATH}
 STATUS=$?
 I=0
 while [[ ${STATUS} -ne 0  && ${I} -lt 50 ]]; do
     echo "Glassfish APIs not deployed yet, retrying in 5 seconds..."
 
     sleep 5
-    wget ${GLASSFISH_SCH}://${GLASSFISH_HOST}:${GLASSFISH_PORT}/${GLASSFISH_PATH}
+    wget -qO- ${GLASSFISH_SCH}://${GLASSFISH_HOST}:${GLASSFISH_PORT}/${GLASSFISH_PATH}
     STATUS=$?
 
     I=${I}+1


### PR DESCRIPTION
Address the issue `wget: can't open 'DSProductInventory': File exists` by preventing the file to be created by wget. As a result, the service can restart in the same container, and we won't need to run `docker-compose down` before `docker-compose up` every single time.